### PR TITLE
Use the  complete GITHUB_SHA as IMAGE_TAG for gar builds

### DIFF
--- a/.github/workflows/gar-build-template.yml
+++ b/.github/workflows/gar-build-template.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Set IMAGE_ID,IMAGE_TAG
         run: |-
-          echo "IMAGE_TAG=$(echo ${{ github.sha }} | cut -c 1-9)" >> $GITHUB_ENV
+          echo "IMAGE_TAG=$GITHUB_SHA" >> $GITHUB_ENV
           echo "IMAGE_ID=${{ inputs.GAR_REPO_DOMAIN }}/${{ inputs.GAR_REPO_PATH }}" >> $GITHUB_ENV
       
       - id: 'auth'


### PR DESCRIPTION
This will make the tagging consistent with ECR template as well as with the commit-to-hellm template.